### PR TITLE
utils-compensation.R: updates for CD45 barcodes.

### DIFF
--- a/R/utils-compensation.R
+++ b/R/utils-compensation.R
@@ -90,7 +90,7 @@
 # Helper functions to get mass and metal from a channel name
 # ------------------------------------------------------------------------------
 .get_ms_from_chs <- function(chs)
-    as.numeric(gsub("[[:punct:][:alpha:]]", "", chs))
+    as.numeric(gsub("[[:punct:][:alpha:]]|CD45", "", chs))
 
 .get_mets_from_chs <- function(chs)
     gsub("([[:punct:]]*)([[:digit:]]*)((Di)|(Dd))*", "", chs)


### PR DESCRIPTION
Hi Helena,
I am currently working with CD45 barcoding. Last time I tried to use `plotMahal` function, it resulted in an error due to the names of the channels (see the [issue 269](https://github.com/HelenaLC/CATALYST/issues/269))
Since, other may experience the same problem, I have changed a littlebit `.get_ms_from_chs` function so that it takes into account this kind of labeling. I have tested this new version with my files and the test files from `CATALYST` package.
Hoping it will be usefull,
Best,
Nicolas